### PR TITLE
Limit housing research reply to five components

### DIFF
--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -13,7 +13,7 @@ import { DATACENTERS, DISTRICT_OPTIONS } from '../../const/housing/housing';
 
 const builder = new SlashCommandSubcommandBuilder()
     .setName('research')
-    .setDescription('Recherchiere interaktiv in einer DM')
+    .setDescription('Recherchiere interaktiv im Chat')
 
 export default {
     name: builder.name,
@@ -21,22 +21,11 @@ export default {
     async execute(interaction: ChatInputCommandInteraction) {
         if (interaction.options.getSubcommand(true) !== builder.name) return;
 
-        await interaction.reply({ content: 'Ich habe dir eine DM Geschickt', flags: MessageFlags.Ephemeral });
-        const dm = await interaction.user.createDM();
-
         const dcRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
                 .setCustomId('research:dc')
                 .setPlaceholder('Datacenter wählen')
                 .addOptions(DATACENTERS.map(d => new StringSelectMenuOptionBuilder().setLabel(d).setValue(d)))
-                .setMinValues(1)
-                .setMaxValues(1),
-        );
-
-        const worldRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-            new StringSelectMenuBuilder()
-                .setCustomId('research:world')
-                .setPlaceholder('Welt wählen')
                 .setMinValues(1)
                 .setMaxValues(1),
         );
@@ -84,6 +73,10 @@ export default {
                 .setStyle(ButtonStyle.Primary),
         );
 
-        await dm.send({ content: 'Housing Research - wähle Filter:', components: [dcRow, worldRow, distRow, fcRow, sizeRow, goRow]});
+        await interaction.reply({
+            content: 'Housing Research - wähle Filter:',
+            components: [dcRow, distRow, fcRow, sizeRow, goRow],
+            flags: MessageFlags.Ephemeral,
+        });
     },
 };

--- a/src/events/housing/housingResearchInteraction.ts
+++ b/src/events/housing/housingResearchInteraction.ts
@@ -40,7 +40,7 @@ export function register(client: Client) {
                 .setMaxValues(1)
             );
             const rows: any[] = [...interaction.message.components];
-            rows[1] = worldRow;
+            rows[0] = worldRow;
             await interaction.update({ components: rows });
           }
           break;


### PR DESCRIPTION
## Summary
- drop placeholder world selector from initial reply to respect Discord's 5-component limit
- swap datacenter select for world select after the datacenter is chosen

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b41e49078883218a4ea2c3900dd0d8