### PR TITLE
Fix housing research command interactions

### DIFF
--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -10,10 +10,11 @@ import {
     ButtonStyle,
 } from 'discord.js';
 import { DATACENTERS, DISTRICT_OPTIONS } from '../../const/housing/housing';
+import { HOUSING_PREFIX } from '../config/housingConfig.js';
 
 const builder = new SlashCommandSubcommandBuilder()
     .setName('research')
-    .setDescription('Recherchiere interaktiv in einer DM')
+    .setDescription('Recherchiere interaktiv im Chat')
 
 export default {
     name: builder.name,
@@ -21,29 +22,20 @@ export default {
     async execute(interaction: ChatInputCommandInteraction) {
         if (interaction.options.getSubcommand(true) !== builder.name) return;
 
-        await interaction.reply({ content: 'Ich habe dir eine DM Geschickt', flags: MessageFlags.Ephemeral });
-        const dm = await interaction.user.createDM();
+        const PREFIX = HOUSING_PREFIX + 'research:';
 
         const dcRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
-                .setCustomId('research:dc')
+                .setCustomId(PREFIX + 'dc')
                 .setPlaceholder('Datacenter wählen')
                 .addOptions(DATACENTERS.map(d => new StringSelectMenuOptionBuilder().setLabel(d).setValue(d)))
                 .setMinValues(1)
                 .setMaxValues(1),
         );
 
-        const worldRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-            new StringSelectMenuBuilder()
-                .setCustomId('research:world')
-                .setPlaceholder('Welt wählen')
-                .setMinValues(1)
-                .setMaxValues(1),
-        );
-
         const distRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
-                .setCustomId('research:district')
+                .setCustomId(PREFIX + 'district')
                 .setPlaceholder('District(s) wählen')
                 .addOptions(DISTRICT_OPTIONS.map(o => new StringSelectMenuOptionBuilder().setLabel(o.label).setValue(o.value)))
                 .setMinValues(0)
@@ -52,7 +44,7 @@ export default {
 
         const fcRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
-                .setCustomId('research:fc')
+                .setCustomId(PREFIX + 'fc')
                 .setPlaceholder('FC Only?')
                 .addOptions(
                     new StringSelectMenuOptionBuilder().setLabel('Beliebig').setValue('any'),
@@ -65,7 +57,7 @@ export default {
 
         const sizeRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
-                .setCustomId('research:size')
+                .setCustomId(PREFIX + 'size')
                 .setPlaceholder('Hausgröße')
                 .addOptions(
                     new StringSelectMenuOptionBuilder().setLabel('Beliebig').setValue('any'),
@@ -79,11 +71,15 @@ export default {
 
         const goRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
             new ButtonBuilder()
-                .setCustomId('research:go')
+                .setCustomId(PREFIX + 'go')
                 .setLabel('Suchen')
                 .setStyle(ButtonStyle.Primary),
         );
 
-        await dm.send({ content: 'Housing Research - wähle Filter:', components: [dcRow, worldRow, distRow, fcRow, sizeRow, goRow]});
+        await interaction.reply({
+            content: 'Housing Research - wähle Filter:',
+            components: [dcRow, distRow, fcRow, sizeRow, goRow],
+            flags: MessageFlags.Ephemeral,
+        });
     },
 };

--- a/src/events/housing/housingResearchInteraction.ts
+++ b/src/events/housing/housingResearchInteraction.ts
@@ -1,7 +1,15 @@
-import { Client, Events, ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from 'discord.js';
+import {
+  Client,
+  Events,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+  MessageFlags,
+} from 'discord.js';
 import { getWorldNamesByDC } from '../../functions/housing/housingWorlds.js';
 import { PaissaProvider } from '../../functions/housing/housingProvider.paissa.js';
 import { plotEmbed } from '../../commands/housing/embed.js';
+import { HOUSING_PREFIX } from '../../commands/config/housingConfig.js';
 
 type ResearchState = {
   dc?: string;
@@ -13,16 +21,18 @@ type ResearchState = {
 
 const mem = new Map<string, ResearchState>();
 
+const PREFIX = HOUSING_PREFIX + 'research:';
+
 export function register(client: Client) {
   client.on(Events.InteractionCreate, async (interaction) => {
     try {
       if (!(interaction.isButton() || interaction.isStringSelectMenu())) return;
-      if (!interaction.customId.startsWith('research:')) return;
+      if (!interaction.customId.startsWith(PREFIX)) return;
 
       const id = interaction.user.id;
       const state: ResearchState = mem.get(id) ?? { districts: [], fc: 'any', size: 'any' };
 
-      const action = interaction.customId.slice('research:'.length);
+      const action = interaction.customId.slice(PREFIX.length);
       switch (action) {
         case 'dc':
           if (interaction.isStringSelectMenu()) {
@@ -33,14 +43,14 @@ export function register(client: Client) {
             const worlds = await getWorldNamesByDC(dc);
             const worldRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
               new StringSelectMenuBuilder()
-                .setCustomId('research:world')
+                .setCustomId(PREFIX + 'world')
                 .setPlaceholder('Welt wählen')
                 .addOptions(worlds.map(w => new StringSelectMenuOptionBuilder().setLabel(w).setValue(w)))
                 .setMinValues(1)
                 .setMaxValues(1)
             );
             const rows: any[] = [...interaction.message.components];
-            rows[1] = worldRow;
+            rows[0] = worldRow;
             await interaction.update({ components: rows });
           }
           break;
@@ -101,9 +111,13 @@ export function register(client: Client) {
     } catch (err) {
       if (interaction.isRepliable()) {
         if (interaction.deferred || interaction.replied) {
-          await interaction.followUp({ content: 'Fehler bei der Recherche.', ephemeral: true }).catch(() => {});
+          await interaction
+            .followUp({ content: 'Fehler bei der Recherche.', flags: MessageFlags.Ephemeral })
+            .catch(() => {});
         } else {
-          await interaction.reply({ content: 'Fehler bei der Recherche.', ephemeral: true }).catch(() => {});
+          await interaction
+            .reply({ content: 'Fehler bei der Recherche.', flags: MessageFlags.Ephemeral })
+            .catch(() => {});
         }
       }
     }


### PR DESCRIPTION
## Summary
- drop placeholder world selector from initial reply to respect Discord's 5-component limit
- swap datacenter select for world select after the datacenter is chosen
- prefix housing research component IDs with the global housing prefix so the router handles them
- use `MessageFlags.Ephemeral` for error replies

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b41e49078883218a4ea2c3900dd0d8