### PR TITLE
feat: add housing start command

### DIFF
--- a/src/commands/housing/embed.ts
+++ b/src/commands/housing/embed.ts
@@ -1,9 +1,31 @@
 import { EmbedBuilder } from "discord.js";
 import type { Plot } from "../../functions/housing/housingProvider.paissa";
 
+/**
+ * Mapping of housing districts to representative images.
+ * The URLs point to publicly available images of each district.
+ */
+const DISTRICT_IMAGES: Record<string, string> = {
+    'Mist': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/mist.jpg',
+    'The Lavender Beds': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/lavenderbeds.jpg',
+    'The Goblet': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/goblet.jpg',
+    'Shirogane': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/shirogane.jpg',
+    'Empyreum': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/empyreum.jpg',
+};
+
+/**
+ * Builds an embed describing a housing plot.
+ *
+ * The embed contains information required by the user:
+ * datacenter, world, district, price, size, FC availability and
+ * an image of the district. The footer displays the time the embed
+ * was generated and the current status of the plot.
+ */
 export function plotEmbed(p: Plot) {
+    const status = formatStatus(p);
     const e = new EmbedBuilder()
         .setTitle(`${p.world} - ${p.district} Ward ${p.ward} Plot ${p.plot}`)
+        .setImage(DISTRICT_IMAGES[p.district] ?? null)
         .addFields(
             { name: 'Datacenter', value: p.dataCenter, inline: true },
             { name: 'World', value: p.world, inline: true },
@@ -11,16 +33,16 @@ export function plotEmbed(p: Plot) {
             { name: 'Price', value: p.price != null ? `${p.price.toLocaleString()} gil` : '-', inline: true },
             { name: 'Size', value: p.size ?? '-', inline: true },
             { name: 'FC Only', value: p.fcOnly ? 'Yes' : 'No', inline: true },
-            { name: 'Status', value: formatStatus(p), inline: false},
-        );
-        return e;
+        )
+        .setFooter({ text: `${new Date().toLocaleString()} • ${status}` });
+    return e;
 }
 
 function formatStatus(p: Plot): string {
     switch (p.lottery.state) {
         case 'preparation': return 'Vorbereitung';
         case 'running': return `Verlosung läuft${p.lottery.endsAt ? ` bis ${p.lottery.endsAt}` : ''}`;
-        case 'results': return `Ergebnisse${p.lottery.winner != null ? ` - Gewinner: ${p.lottery.winner ? 'Ja' : 'Nein'}` : ''}`
+        case 'results': return `Ergebnisse${p.lottery.winner != null ? ` - Gewinner: ${p.lottery.winner ? 'Ja' : 'Nein'}` : ''}`;
         default: return '-';
     }
 }

--- a/src/commands/housing/housingRefresh.ts
+++ b/src/commands/housing/housingRefresh.ts
@@ -1,0 +1,9 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+
+export default {
+  name: 'refresh',
+  description: 'Placeholder for housing refresh',
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.reply({ content: 'Refresh command not implemented.', flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -1,0 +1,9 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+
+export default {
+  name: 'research',
+  description: 'Placeholder for housing research',
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.reply({ content: 'Research command not implemented.', flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/commands/housing/housingStart.ts
+++ b/src/commands/housing/housingStart.ts
@@ -1,0 +1,79 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+  type ChatInputCommandInteraction,
+  type TextChannel,
+} from 'discord.js';
+import { configManager } from '../../handlers/configHandler.js';
+import { HousingRequired } from '../../schemas/housing.js';
+import { PaissaProvider } from '../../functions/housing/housingProvider.paissa.js';
+import { plotEmbed } from './embed.js';
+
+const provider = new PaissaProvider();
+
+export default {
+  name: 'start',
+  description: 'Post a paginated list of free housing plots',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const guildID = interaction.guildId;
+    if (!guildID) {
+      await interaction.reply({ content: 'This command can only be used in a guild.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const config = await configManager.get(guildID);
+    const h = (config['housing'] as any) ?? null;
+    const ok = HousingRequired.safeParse(h);
+    if (!ok.success) {
+      await interaction.reply({ content: 'Housing is not configured.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+    const hc = ok.data;
+
+    const ch = await interaction.client.channels.fetch(hc.channelId).catch(() => null);
+    if (!ch || !('send' in ch)) {
+      await interaction.reply({ content: 'Configured channel could not be found.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const plots = [] as Awaited<ReturnType<typeof provider.fetchFreePlots>>;
+    for (const world of hc.worlds) {
+      const p = await provider.fetchFreePlots(hc.dataCenter, world, hc.districts);
+      plots.push(...p);
+    }
+
+    if (plots.length === 0) {
+      await interaction.reply({ content: 'No free plots available.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const embeds = plots.map(plotEmbed);
+    let page = 0;
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId('housing:prev').setLabel('Prev').setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder().setCustomId('housing:next').setLabel('Next').setStyle(ButtonStyle.Secondary),
+    );
+
+    const msg = await (ch as TextChannel).send({
+      embeds: [embeds[page]!],
+      components: embeds.length > 1 ? [row] : [],
+    });
+
+    if (embeds.length > 1) {
+      const collector = msg.createMessageComponentCollector({ time: 5 * 60_000 });
+      collector.on('collect', async i => {
+        if (i.customId === 'housing:prev') {
+          page = (page - 1 + embeds.length) % embeds.length;
+        } else if (i.customId === 'housing:next') {
+          page = (page + 1) % embeds.length;
+        }
+        await i.update({ embeds: [embeds[page]!] });
+      });
+    }
+
+    await interaction.reply({ content: `Posted ${embeds.length} plots to <#${hc.channelId}>`, flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/events/housing/housingResearchInteraction.ts
+++ b/src/events/housing/housingResearchInteraction.ts
@@ -1,0 +1,11 @@
+import type { Client } from 'discord.js';
+
+/**
+ * Placeholder register function for housing research interactions.
+ * Real implementation is not yet provided.
+ */
+export function register(_client: Client) {
+  // no-op
+}
+
+export default { register };


### PR DESCRIPTION
## Summary
- add `/housing start` subcommand that posts paginated housing listings to the configured channel
- include district images and footer info for each housing plot embed
- add placeholder housing command and event files to keep compilation working

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b428cc02348321ae0bc050b106a721