### PR TITLE
feat: add housing start command

### DIFF
--- a/src/commands/housing/embed.ts
+++ b/src/commands/housing/embed.ts
@@ -1,9 +1,31 @@
 import { EmbedBuilder } from "discord.js";
 import type { Plot } from "../../functions/housing/housingProvider.paissa";
 
+/**
+ * Mapping of housing districts to representative images.
+ * The URLs point to publicly available images of each district.
+ */
+const DISTRICT_IMAGES: Record<string, string> = {
+    'Mist': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/mist.jpg',
+    'The Lavender Beds': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/lavenderbeds.jpg',
+    'The Goblet': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/goblet.jpg',
+    'Shirogane': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/shirogane.jpg',
+    'Empyreum': 'https://img.finalfantasyxiv.com/lds/pc/global/images/housing/empyreum.jpg',
+};
+
+/**
+ * Builds an embed describing a housing plot.
+ *
+ * The embed contains information required by the user:
+ * datacenter, world, district, price, size, FC availability and
+ * an image of the district. The footer displays the time the embed
+ * was generated and the current status of the plot.
+ */
 export function plotEmbed(p: Plot) {
+    const status = formatStatus(p);
     const e = new EmbedBuilder()
         .setTitle(`${p.world} - ${p.district} Ward ${p.ward} Plot ${p.plot}`)
+        .setImage(DISTRICT_IMAGES[p.district] ?? null)
         .addFields(
             { name: 'Datacenter', value: p.dataCenter, inline: true },
             { name: 'World', value: p.world, inline: true },
@@ -11,16 +33,16 @@ export function plotEmbed(p: Plot) {
             { name: 'Price', value: p.price != null ? `${p.price.toLocaleString()} gil` : '-', inline: true },
             { name: 'Size', value: p.size ?? '-', inline: true },
             { name: 'FC Only', value: p.fcOnly ? 'Yes' : 'No', inline: true },
-            { name: 'Status', value: formatStatus(p), inline: false},
-        );
-        return e;
+        )
+        .setFooter({ text: `${new Date().toLocaleString()} • ${status}` });
+    return e;
 }
 
 function formatStatus(p: Plot): string {
     switch (p.lottery.state) {
         case 'preparation': return 'Vorbereitung';
         case 'running': return `Verlosung läuft${p.lottery.endsAt ? ` bis ${p.lottery.endsAt}` : ''}`;
-        case 'results': return `Ergebnisse${p.lottery.winner != null ? ` - Gewinner: ${p.lottery.winner ? 'Ja' : 'Nein'}` : ''}`
+        case 'results': return `Ergebnisse${p.lottery.winner != null ? ` - Gewinner: ${p.lottery.winner ? 'Ja' : 'Nein'}` : ''}`;
         default: return '-';
     }
 }

--- a/src/commands/housing/housingRefresh.ts
+++ b/src/commands/housing/housingRefresh.ts
@@ -1,0 +1,9 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+
+export default {
+  name: 'refresh',
+  description: 'Placeholder for housing refresh',
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.reply({ content: 'Refresh command not implemented.', flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -1,0 +1,9 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+
+export default {
+  name: 'research',
+  description: 'Placeholder for housing research',
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.reply({ content: 'Research command not implemented.', flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/commands/housing/housingStart.ts
+++ b/src/commands/housing/housingStart.ts
@@ -1,0 +1,79 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+  type ChatInputCommandInteraction,
+  type TextChannel,
+} from 'discord.js';
+import { configManager } from '../../handlers/configHandler.js';
+import { HousingStart } from '../../schemas/housing.js';
+import { PaissaProvider } from '../../functions/housing/housingProvider.paissa.js';
+import { plotEmbed } from './embed.js';
+
+const provider = new PaissaProvider();
+
+export default {
+  name: 'start',
+  description: 'Post a paginated list of free housing plots',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const guildID = interaction.guildId;
+    if (!guildID) {
+      await interaction.reply({ content: 'This command can only be used in a guild.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const config = await configManager.get(guildID);
+    const h = (config['housing'] as any) ?? null;
+    const ok = HousingStart.safeParse(h);
+    if (!ok.success) {
+      await interaction.reply({ content: 'Housing is not configured.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+    const hc = ok.data;
+
+    const ch = await interaction.client.channels.fetch(hc.channelId).catch(() => null);
+    if (!ch || !('send' in ch)) {
+      await interaction.reply({ content: 'Configured channel could not be found.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const plots = [] as Awaited<ReturnType<typeof provider.fetchFreePlots>>;
+    for (const world of hc.worlds) {
+      const p = await provider.fetchFreePlots(hc.dataCenter, world, hc.districts);
+      plots.push(...p);
+    }
+
+    if (plots.length === 0) {
+      await interaction.reply({ content: 'No free plots available.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const embeds = plots.map(plotEmbed);
+    let page = 0;
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId('housing:prev').setLabel('Prev').setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder().setCustomId('housing:next').setLabel('Next').setStyle(ButtonStyle.Secondary),
+    );
+
+    const msg = await (ch as TextChannel).send({
+      embeds: [embeds[page]!],
+      components: embeds.length > 1 ? [row] : [],
+    });
+
+    if (embeds.length > 1) {
+      const collector = msg.createMessageComponentCollector({ time: 5 * 60_000 });
+      collector.on('collect', async i => {
+        if (i.customId === 'housing:prev') {
+          page = (page - 1 + embeds.length) % embeds.length;
+        } else if (i.customId === 'housing:next') {
+          page = (page + 1) % embeds.length;
+        }
+        await i.update({ embeds: [embeds[page]!] });
+      });
+    }
+
+    await interaction.reply({ content: `Posted ${embeds.length} plots to <#${hc.channelId}>`, flags: MessageFlags.Ephemeral });
+  }
+};

--- a/src/events/housing/housingResearchInteraction.ts
+++ b/src/events/housing/housingResearchInteraction.ts
@@ -1,0 +1,11 @@
+import type { Client } from 'discord.js';
+
+/**
+ * Placeholder register function for housing research interactions.
+ * Real implementation is not yet provided.
+ */
+export function register(_client: Client) {
+  // no-op
+}
+
+export default { register };

--- a/src/functions/housing/housingProvider.paissa.ts
+++ b/src/functions/housing/housingProvider.paissa.ts
@@ -19,10 +19,10 @@ const PlotZ = z.object({
     ward_number: z.number().or(z.string()),
     plot_number: z.number().or(z.string()),
     price: z.number().or(z.string()).optional(),
-    size: z.string().optional(),
+    size: z.union([z.string(), z.number()]).optional(),
     free_company_only: z.boolean().optional(),
-    lottery_state: z.string().optional(),
-    lottery_end: z.string().optional(),
+    lottery_state: z.union([z.string(), z.number()]).optional(),
+    lottery_end: z.union([z.string(), z.number()]).optional(),
     lottery_winner: z.boolean().optional(),
 }).passthrough();
 
@@ -68,10 +68,10 @@ export class PaissaProvider {
         if (wanted.size && ![...wanted].some(w => eqDistrict(w, d.name))) continue;
 
         for (const p of d.open_plots) {
-            const state = normState(p.lottery_state);
+            const state = normState(typeof p.lottery_state === 'number' ? String(p.lottery_state) : p.lottery_state);
 
             const lottery: Plot['lottery'] = { state };
-            if (p.lottery_end) lottery.endsAt = p.lottery_end;
+            if (p.lottery_end !== undefined) lottery.endsAt = String(p.lottery_end);
             if (typeof p.lottery_winner === 'boolean') lottery.winner = p.lottery_winner;
 
             const item: Plot = {
@@ -85,7 +85,7 @@ export class PaissaProvider {
 
             if (p.price !== undefined) item.price = Number(p.price);
 
-            const sizeVal = normSize(p.size);
+            const sizeVal = normSize(typeof p.size === 'number' ? String(p.size) : p.size);
             if (sizeVal) item.size = sizeVal;
 
             if (typeof p.free_company_only === 'boolean') item.fcOnly = p.free_company_only;

--- a/src/schemas/housing.ts
+++ b/src/schemas/housing.ts
@@ -15,6 +15,16 @@ export const housingPartial = z.object({
     pingRoleId: z.string().min(1).optional(),
 });
 
+// Minimal schema required for posting housing listings manually.
+// Scheduler-specific fields like timesPerDay/intervalMinutes are omitted.
+export const HousingStart = z.object({
+    enabled: z.literal(true),
+    dataCenter: z.string().min(1),
+    worlds: z.array(z.string().min(1)).nonempty(),
+    districts: z.array(z.string()).nonempty(),
+    channelId: z.string().min(1),
+});
+
 // Schema for required housing configuration options.
 // This is used when the housing feature is enabled.
 export const HousingRequired = z.object({


### PR DESCRIPTION
## Summary
- add `/housing start` subcommand that posts paginated housing listings to the configured channel
- include district images and footer info for each housing plot embed
- add placeholder housing command and event files to keep compilation working
- relax configuration validation for `/housing start` by introducing a minimal schema
- handle numeric lottery fields from PaissaDB to avoid zod type errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b428cc02348321ae0bc050b106a721