### PR TITLE
feat(housing): post plots to forum threads

### DIFF
--- a/src/commands/config/housingConfig.ts
+++ b/src/commands/config/housingConfig.ts
@@ -99,7 +99,7 @@ async function handle(interaction: ChatInputCommandInteraction) {
   const chBuilder = new ChannelSelectMenuBuilder()
     .setCustomId(PREFIX + "channel")
     .setPlaceholder("Zielkanal")
-    .addChannelTypes(ChannelType.GuildText)
+    .addChannelTypes(ChannelType.GuildText, ChannelType.GuildForum)
     .setMinValues(0)
     .setMaxValues(1);
   if (h.channelId) chBuilder.setDefaultChannels(h.channelId);

--- a/src/commands/housing/embed.ts
+++ b/src/commands/housing/embed.ts
@@ -1,6 +1,7 @@
-import { EmbedBuilder } from "discord.js";
-import type { Plot } from "../../functions/housing/housingProvider.paissa";
-import { DISTRICT_IMAGES } from "../../const/housing/housing";
+import { AttachmentBuilder, EmbedBuilder } from 'discord.js';
+import { fileURLToPath } from 'node:url';
+import type { Plot } from '../../functions/housing/housingProvider.paissa';
+import { DISTRICT_IMAGES } from '../../const/housing/housing';
 
 /**
  * Builds an embed describing a housing plot.
@@ -12,9 +13,8 @@ import { DISTRICT_IMAGES } from "../../const/housing/housing";
  */
 export function plotEmbed(p: Plot) {
     const status = formatStatus(p);
-    const e = new EmbedBuilder()
+    const embed = new EmbedBuilder()
         .setTitle(`${p.world} - ${p.district} Ward ${p.ward} Plot ${p.plot}`)
-        .setImage(DISTRICT_IMAGES[p.district] ?? null)
         .addFields(
             { name: 'Datacenter', value: p.dataCenter, inline: true },
             { name: 'World', value: p.world, inline: true },
@@ -24,7 +24,17 @@ export function plotEmbed(p: Plot) {
             { name: 'FC Only', value: p.fcOnly ? 'Yes' : 'No', inline: true },
         )
         .setFooter({ text: `${new Date().toLocaleString()} • ${status}` });
-    return e;
+
+    const imgFile = DISTRICT_IMAGES[p.district];
+    let attachment: AttachmentBuilder | undefined;
+
+    if (imgFile) {
+        const url = new URL(`../../img/housing/${imgFile}`, import.meta.url);
+        attachment = new AttachmentBuilder(fileURLToPath(url));
+        embed.setImage(`attachment://${imgFile}`);
+    }
+
+    return { embed, attachment };
 }
 
 function formatStatus(p: Plot): string {

--- a/src/commands/housing/housingStart.ts
+++ b/src/commands/housing/housingStart.ts
@@ -1,10 +1,8 @@
 import {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
+  ChannelType,
   MessageFlags,
   type ChatInputCommandInteraction,
-  type TextChannel,
+  type ForumChannel,
 } from 'discord.js';
 import { configManager } from '../../handlers/configHandler.js';
 import { HousingStart } from '../../schemas/housing.js';
@@ -15,7 +13,7 @@ const provider = new PaissaProvider();
 
 export default {
   name: 'start',
-  description: 'Post a paginated list of free housing plots',
+  description: 'Post a list of free housing plots grouped by district',
   async execute(interaction: ChatInputCommandInteraction) {
     const guildID = interaction.guildId;
     if (!guildID) {
@@ -33,8 +31,8 @@ export default {
     const hc = ok.data;
 
     const ch = await interaction.client.channels.fetch(hc.channelId).catch(() => null);
-    if (!ch || !('send' in ch)) {
-      await interaction.reply({ content: 'Configured channel could not be found.', flags: MessageFlags.Ephemeral });
+    if (!ch || ch.type !== ChannelType.GuildForum) {
+      await interaction.reply({ content: 'Configured channel could not be found or is not a forum.', flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -49,31 +47,32 @@ export default {
       return;
     }
 
-    const embeds = plots.map(plotEmbed);
-    let page = 0;
-
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder().setCustomId('housing:prev').setLabel('Prev').setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder().setCustomId('housing:next').setLabel('Next').setStyle(ButtonStyle.Secondary),
-    );
-
-    const msg = await (ch as TextChannel).send({
-      embeds: [embeds[page]!],
-      components: embeds.length > 1 ? [row] : [],
-    });
-
-    if (embeds.length > 1) {
-      const collector = msg.createMessageComponentCollector({ time: 5 * 60_000 });
-      collector.on('collect', async i => {
-        if (i.customId === 'housing:prev') {
-          page = (page - 1 + embeds.length) % embeds.length;
-        } else if (i.customId === 'housing:next') {
-          page = (page + 1) % embeds.length;
-        }
-        await i.update({ embeds: [embeds[page]!] });
-      });
+    const byDistrict = new Map<string, typeof plots>();
+    for (const p of plots) {
+      const arr = byDistrict.get(p.district) ?? [];
+      arr.push(p);
+      byDistrict.set(p.district, arr);
     }
 
-    await interaction.reply({ content: `Posted ${embeds.length} plots to <#${hc.channelId}>`, flags: MessageFlags.Ephemeral });
+    let total = 0;
+    for (const [district, list] of byDistrict) {
+      const first = list[0]!;
+      const { embed, attachment } = plotEmbed(first);
+      const thread = await (ch as ForumChannel).threads.create({
+        name: district,
+        message: {
+          embeds: [embed],
+          files: attachment ? [attachment] : [],
+        },
+      });
+
+      for (const p of list.slice(1)) {
+        const { embed: e, attachment: a } = plotEmbed(p);
+        await thread.send({ embeds: [e], files: a ? [a] : [] });
+      }
+      total += list.length;
+    }
+
+    await interaction.reply({ content: `Posted ${total} plots across ${byDistrict.size} districts to <#${hc.channelId}>`, flags: MessageFlags.Ephemeral });
   }
 };

--- a/src/const/housing/housing.ts
+++ b/src/const/housing/housing.ts
@@ -8,10 +8,13 @@ export const DISTRICT_OPTIONS = [
     { label: 'Empyreum', value: 'Empyreum' },
 ];
 
+// Mapping of housing districts to their corresponding image filenames.
+// The actual path resolution and attachment handling is performed when
+// building the embed for a specific plot.
 export const DISTRICT_IMAGES: Record<string, string> = {
-    'Mist': '../../img/housing/mist_district_discord.png',
-    'The Lavender Beds': '../../img/housing/lavender_beds_discord.png',
-    'The Goblet': '../../img/housing/the_goblet_discord.png',
-    'Shirogane': '../../img/housing/shirogane_discord.png',
-    'Empyreum': '../../img/housing/empyreum_discord.png',
+    Mist: 'mist_district_discord.png',
+    'The Lavender Beds': 'lavender_beds_discord.png',
+    'The Goblet': 'the_goblet_discord.png',
+    Shirogane: 'shirogane_discord.png',
+    Empyreum: 'empyreum_discord.png',
 };


### PR DESCRIPTION
## Summary
- group `/housing start` results by district and post each to its own forum thread
- attach district images to housing embeds
- send images with automated housing runner posts
- allow selecting forum channels in housing config and post runner updates to threads

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b44bd050888321a56e5d1f7c2ad128