### PR TITLE
feat: extend housing start options with pings

### DIFF
--- a/src/commands/housing/housing.ts
+++ b/src/commands/housing/housing.ts
@@ -1,5 +1,5 @@
 
-import { SlashCommandBuilder, MessageFlags, type ChatInputCommandInteraction, type Interaction, Message } from "discord.js";
+import { SlashCommandBuilder, MessageFlags, type ChatInputCommandInteraction, type SlashCommandSubcommandBuilder } from "discord.js";
 import type { Command } from "../../handlers/commandHandler";
 
 import start from './housingStart';
@@ -9,6 +9,7 @@ import research from './housingResearch';
 type Sub = {
     name: string;
     description: string;
+    build?: (sc: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder;
     execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
 };
 
@@ -19,7 +20,11 @@ export const data = (() => {
         .setName('housing')
         .setDescription('Housing utilities');
     for (const s of SUBS) {
-        command.addSubcommand(sc => sc.setName(s.name).setDescription(s.description));
+        command.addSubcommand(sc => {
+            sc.setName(s.name).setDescription(s.description);
+            if (s.build) s.build(sc);
+            return sc;
+        });
     }
     return command;
 })();

--- a/src/schemas/housing.ts
+++ b/src/schemas/housing.ts
@@ -23,6 +23,8 @@ export const HousingStart = z.object({
     worlds: z.array(z.string().min(1)).nonempty(),
     districts: z.array(z.string()).nonempty(),
     channelId: z.string().min(1),
+    pingUserId: z.string().min(1).optional(),
+    pingRoleId: z.string().min(1).optional(),
 });
 
 // Schema for required housing configuration options.


### PR DESCRIPTION
## Summary
- allow `/housing start` to use stored config or manual datacenter/world/district/channel options
- support user and role pings in posted housing embed messages
- capture optional ping fields in housing schema

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4537f97d883218842a2c5ae0c62b4