### PR TITLE
Implement housing message sync protections

### DIFF
--- a/src/commands/housing/housingRefresh.ts
+++ b/src/commands/housing/housingRefresh.ts
@@ -11,7 +11,7 @@ export default {
       return;
     }
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-    const { added, removed } = await refreshHousing(interaction.client, guildID);
-    await interaction.editReply({ content: `Housing refreshed. ${added} added, ${removed} removed.` });
+    const { added, removed, updated } = await refreshHousing(interaction.client, guildID);
+    await interaction.editReply({ content: `Housing refreshed. ${added} added, ${removed} removed, ${updated} updated.` });
   }
 };

--- a/src/functions/housing/housingMessageWatcher.ts
+++ b/src/functions/housing/housingMessageWatcher.ts
@@ -1,0 +1,47 @@
+import type { Client } from 'discord.js';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+type MsgRecord = {
+  channelId: string;
+  threads: Record<string, string>;
+  messages: Record<string, { threadId: string; messageId: string; hash?: string }>;
+};
+
+const filePath = path.join(process.cwd(), 'src', 'guildconfig', 'housing_messages.json');
+
+export function startHousingMessageWatcher(client: Client) {
+  setInterval(async () => {
+    if (!client.isReady()) return;
+
+    let store: Record<string, MsgRecord> = {};
+    try {
+      store = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, MsgRecord>;
+    } catch {
+      return;
+    }
+
+    let changed = false;
+
+    for (const rec of Object.values(store)) {
+      for (const [key, info] of Object.entries(rec.messages)) {
+        const thread = await client.channels.fetch(info.threadId).catch(() => null);
+        if (!thread || !thread.isTextBased()) {
+          delete rec.messages[key];
+          changed = true;
+          continue;
+        }
+        const msg = await thread.messages.fetch(info.messageId).catch(() => null);
+        if (!msg) {
+          delete rec.messages[key];
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      await writeFile(filePath, JSON.stringify(store, null, 2), 'utf8').catch(() => {});
+    }
+  }, 10_000);
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { logger } from './lib/logger.js';
 import { commands } from './handlers/commandInit.js';
 import { commandHandler } from './handlers/commandHandler.js';
 import { registerEvents } from './events/index.js';
+import { startHousingMessageWatcher } from './functions/housing/housingMessageWatcher.js';
 
 // Ensure the Discord token is available. Without it the bot cannot start.
 const token = process.env.DISCORD_TOKEN;
@@ -25,6 +26,7 @@ commandHandler.registerAll(commands);
 
 // Set up event listeners.
 registerEvents(client);
+startHousingMessageWatcher(client);
 
 // Finally log in using the provided token. Any login failure is fatal.
 client.login(token).catch((e) => {


### PR DESCRIPTION
## Summary
- Avoid reposting existing housing plots in `/housing start`
- Refresh housing posts only when API data changes and report update counts
- Periodically prune missing housing messages from config

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4999c1bd08321b1039ef0dd81c50f